### PR TITLE
Fix Vercel Next build: install autoprefixer during build

### DIFF
--- a/apps/demo/client/package.json
+++ b/apps/demo/client/package.json
@@ -11,6 +11,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.16",
+    "autoprefixer": "^10.4.21",
     "@coinbase/cdp-core": "latest",
     "@coinbase/cdp-hooks": "^0.0.66",
     "@coinbase/cdp-react": "latest",
@@ -54,6 +56,7 @@
     "lucide-react": "^0.462.0",
     "next": "^14.2.0",
     "next-themes": "^0.3.0",
+    "postcss": "^8.5.6",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -62,6 +65,7 @@
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
+    "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
     "viem": "^2.39.3",
@@ -70,16 +74,12 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
-    "autoprefixer": "^10.4.21",
     "concurrently": "^8.2.2",
     "eslint": "^8",
     "eslint-config-next": "14.2.0",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
This fixes a Vercel build failure:

> Error: Cannot find module 'autoprefixer'

The client has `postcss.config.js` and `tailwind.config.ts` that require build-time CSS tooling. On some Vercel configurations devDependencies may be omitted during build, so this moves the PostCSS/Tailwind toolchain dependencies into `dependencies` for the Next.js client.

Changes:
- Move `autoprefixer`, `postcss`, `tailwindcss`, and `@tailwindcss/typography` to `apps/demo/client` dependencies.

After merge, Vercel should rebuild successfully on `main`.