### PR TITLE
chore(devcontainer): add MCP toolchain + hackmoney scratchpad

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,86 @@
+{
+  "mcpServers": {
+    "blockscout": {
+      "url": "https://mcp.blockscout.com/mcp",
+      "transport": "http",
+      "headers": {}
+    },
+    "Context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "transport": "http",
+      "headers": {}
+    },
+    "etherscan": {
+      "command": "etherscan-mcp-server",
+      "args": [],
+      "env": {
+        "ETHERSCAN_API_KEY": "${env:ETHERSCAN_API_KEY}"
+      }
+    },
+    "alchemy": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@alchemy/mcp-server"
+      ],
+      "env": {
+        "ALCHEMY_API_KEY": "${env:ALCHEMY_API_KEY}"
+      }
+    },
+    "self-mcp": {
+      "command": "python3",
+      "args": [
+        "-m",
+        "self_mcp.server"
+      ]
+    },
+    "circle": {
+      "url": "https://api.circle.com/v1/codegen/mcp",
+      "transport": "http",
+      "headers": {}
+    },
+    "ens": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-ens"
+      ],
+      "env": {
+        "PROVIDER_URL": "${env:ENS_PROVIDER_URL}"
+      }
+    },
+    "sui-tools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "sui-mcp@latest"
+      ]
+    },
+    "lifi": {
+      "command": "lifi-mcp",
+      "args": []
+    },
+    "tavily-remote-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.tavily.com/mcp/?tavilyApiKey=${env:TAVILY_API_KEY}"
+      ],
+      "env": {
+        "TAVILY_API_KEY": "${env:TAVILY_API_KEY}"
+      }
+    },
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    },
+    "Coinbase Developer": {
+      "name": "Coinbase Developer",
+      "url": "https://docs.cdp.coinbase.com/mcp",
+      "headers": {}
+    }
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,9 +17,23 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     ca-certificates \
     build-essential \
     curl \
+    git \
+    golang-go \
     gnupg \
+    python3 \
+    python3-pip \
+    python3-venv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install binaries / python libs used by MCP servers (test-wallet only).
+# - lifi-mcp: https://github.com/lifinance/lifi-mcp
+# - self-mcp: https://github.com/selfxyz/self-mcp
+# - etherscan-mcp-server: https://github.com/huahuayu/etherscan-mcp-server
+RUN GOBIN=/usr/local/bin go install github.com/lifinance/lifi-mcp@latest
+RUN GOBIN=/usr/local/bin go install github.com/huahuayu/etherscan-mcp-server/cmd/etherscan-mcp-server@latest
+RUN pip3 install --no-cache-dir --break-system-packages \
+    "git+https://github.com/selfxyz/self-mcp.git"
 
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor -o /etc/apt/keyrings/1password-archive-keyring.gpg \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,9 @@
       "nodeGypDependencies": true,
       "installYarnUsingApt": true
     },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "latest"
     }
@@ -115,9 +118,19 @@
   },
 
   "remoteEnv": {
-    "PATH": "${containerEnv:PATH}:/home/vscode/.foundry/bin",
-    "EDITOR": "code --wait"
+    "PATH": "${containerEnv:PATH}:/home/vscode/.foundry/bin:/home/vscode/go/bin:/home/vscode/.local/bin",
+    "EDITOR": "code --wait",
+    "TAVILY_API_KEY": "${localEnv:TAVILY_API_KEY}",
+    "ALCHEMY_API_KEY": "${localEnv:ALCHEMY_API_KEY}",
+    "ETHERSCAN_API_KEY": "${localEnv:ETHERSCAN_API_KEY}",
+    "ETHERSCAN_BEARER_TOKEN": "${localEnv:ETHERSCAN_BEARER_TOKEN}",
+    "TENDERLY_ACCOUNT_SLUG": "${localEnv:TENDERLY_ACCOUNT_SLUG}",
+    "TENDERLY_PROJECT_ID": "${localEnv:TENDERLY_PROJECT_ID}",
+    "TENDERLY_ACCESS_TOKEN": "${localEnv:TENDERLY_ACCESS_TOKEN}",
+    "ENS_PROVIDER_URL": "${localEnv:ENS_PROVIDER_URL}"
   },
+
+  "postCreateCommand": "bash -lc \"echo '[postCreate] installing hackmoney tool deps' && npm install --no-package-lock --prefix .devcontainer/hackmoney-tools\"",
 
   "mounts": [
     {

--- a/.devcontainer/hackmoney-tools/package.json
+++ b/.devcontainer/hackmoney-tools/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hackmoney-tools",
+  "private": true,
+  "description": "Scratchpad deps for hackathon prototyping (kept out of app deps).",
+  "dependencies": {
+    "@circle-fin/circle-sdk": "latest",
+    "@erc7824/nitrolite": "latest",
+    "@ensdomains/ensjs": "latest",
+    "@lifi/sdk": "latest",
+    "@mysten/sui": "latest",
+    "@tenderly/sdk": "latest",
+    "@uniswap/sdk-core": "latest",
+    "@uniswap/v4-sdk": "latest",
+    "@uniswap/v3-sdk": "latest",
+    "ethers": "latest",
+    "viem": "latest"
+  }
+}
+

--- a/hackmoney.md
+++ b/hackmoney.md
@@ -1,0 +1,125 @@
+# HackMoney notes (zkx402)
+
+Quick cheat-sheet for a hackathon build using this repo + the MCP servers we’ve wired up.
+
+## MCP servers configured in this repo
+
+Configured in `.cursor/mcp.json`:
+
+- **Context7 (`Context7`)**: library/package docs (best for SDK APIs, not product marketing sites)
+- **Web search (`tavily-remote-mcp`)**: find canonical docs/pages quickly
+- **Browser automation (`playwright`)**: validate UI flows in a real browser
+
+### Chain + explorer + simulation
+
+- **Blockscout (`blockscout`)**: multi-chain explorer data via MCP  
+  Docs: `https://docs.blockscout.com/devs/mcp-server`
+- **Etherscan (`etherscan`)**: explorer + MCP tools (early-access bearer token)  
+  Docs: `https://docs.etherscan.io/mcp`
+- **Alchemy (`alchemy`)**: multichain data APIs via MCP  
+  Repo/docs: `https://github.com/alchemyplatform/alchemy-mcp-server`
+- **Tenderly (`tenderly`)**: tx simulation / debugging via MCP  
+  Community server (env vars): `TENDERLY_ACCOUNT_SLUG`, `TENDERLY_PROJECT_ID`, `TENDERLY_ACCESS_TOKEN`
+
+### Identity / payments / naming
+
+- **Self Protocol (`self-mcp`)**: Self integration helpers + read-only chain operations  
+  Repo: `https://github.com/selfxyz/self-mcp`  
+  Install (once, in the environment running MCP servers):
+  - `pip install git+https://github.com/selfxyz/self-mcp.git`
+- **Circle (`circle`)**: Circle “Build with AI” MCP (Wallets, Contracts, CCTP, Bridge Kit, Gateway)  
+  Docs: `https://developers.circle.com/ai/mcp`
+- **ENS (`ens`)**: dedicated ENS MCP (resolve names, reverse lookup, records, availability, pricing, history)  
+  Repo: `https://github.com/JustaName-id/ens-mcp-server`
+
+## Environment variables to set (devcontainer-friendly)
+
+These are referenced by `.cursor/mcp.json` and `.devcontainer/devcontainer.json`:
+
+- **`TAVILY_API_KEY`**: web search MCP
+- **`ALCHEMY_API_KEY`**: Alchemy MCP
+- **`ETHERSCAN_BEARER_TOKEN`**: Etherscan MCP (early access; bearer token)
+- **`TENDERLY_ACCOUNT_SLUG` / `TENDERLY_PROJECT_ID` / `TENDERLY_ACCESS_TOKEN`**: Tenderly MCP
+- **`ENS_PROVIDER_URL`**: optional RPC URL(s) for ENS MCP (comma-separated list supported). If unset, it may fall back to public RPCs per the ENS MCP README.
+
+## Network focus (quick mapping)
+
+- **Base Sepolia**
+  - Prefer: **Blockscout** + **Alchemy**
+  - Use Tenderly when you need trace/sim
+- **Ethereum mainnet**
+  - Prefer: **Etherscan** + **Alchemy**
+  - ENS lookups: **ENS MCP** (or Etherscan’s ENS tools if your bearer token works)
+- **Self Protocol networks**
+  - Use **Self MCP** (its tools mention Celo mainnet/testnet support)
+
+## Docs that are usually *not* in Context7
+
+Context7 is strongest for **versioned library docs** (e.g., npm/pip packages). For these, prefer canonical docs:
+
+- Circle product docs: `https://developers.circle.com/`
+- Yellow / ERC-7824:
+  - Yellow quickstart: `https://docs.yellow.org/docs/build/quick-start/`
+  - Smart clearing protocol: `https://docs.yellow.org/yellow-network/architecture-and-design/smart-clearing-protocol`
+  - ERC-7824 hub: `https://erc7824.org/`
+- ENS protocol docs: `https://docs.ens.domains/` (Context7 may still help for ENS *libraries*, e.g. `@ensdomains/ensjs`)
+
+## Uniswap Foundation “About” (for writeups / slides)
+
+Canonical page: `https://uniswapfoundation.org/about`
+
+Key copy points from the page:
+- Uniswap is described as “the world’s largest decentralized trading protocol” (25M+ wallets, $2.55T+ lifetime volume).
+- The Uniswap Foundation (founded 2022) focuses on growth/sustainability/decentralization of the community.
+- Foundation expansion in 2024 includes builder programs for **Unichain** and **Uniswap v4**.
+
+## Optional: Uniswap MCP servers (community)
+
+Not official Uniswap Foundation tooling, but useful for hackathon prototyping:
+
+- Uniswap pools data MCP (community): `https://mcpservers.org/servers/kukapay/uniswap-pools-mcp`
+- Uniswap trader MCP (community): `https://github.com/kukapay/uniswap-trader-mcp`
+
+## Sui track notes (prizes + resources)
+
+About (from the prompt):
+- Sui positions itself as “high performance, strong security, and deep composability” aimed at DeFi at real-world scale.
+- They’re looking for teams to continue beyond the hackathon via a longer-term relationship (including their Moonshot Program).
+
+Prizes (from the prompt):
+- **Best Overall Project**: $3,000
+- **Notable Projects**: $7,000 total (up to 7 teams × $1,000)
+
+Qualification checklist (copy/paste friendly):
+- Built on Sui and meaningfully uses Sui-specific capabilities
+- Working prototype / functional demo
+- Clear explanation of the problem + why Sui is well-suited
+- Strong execution (Best Overall: at least 2 areas; Notable: at least 1 area)
+- Potential for continued development beyond the hackathon
+
+Resources:
+- Getting started: `https://docs.sui.io/guides/developer/getting-started`
+- Intro to PTBs (TypeScript SDK): `https://docs.sui.io/guides/developer/sui-101/building-ptb`
+- DeepBook docs: `https://docs.sui.io/standards/deepbook`
+- DeepBookV3 repo: `https://github.com/MystenLabs/deepbookv3`
+- Sui DeFi overview: `https://www.sui.io/defi`
+
+MCP angle:
+- There’s no clearly “official Mysten Labs” MCP server, but there are community Sui MCP servers (example: `https://github.com/deanpluse/sui-mcp`) that provide faucet/balance/transfer tools.
+- For “how do I build X on Sui?” questions, the canonical source is Sui Docs (above); Context7 is most useful when you’re integrating a specific SDK package API surface.
+
+## LI.FI notes (bridge + DEX aggregation)
+
+About (matches the “Advanced Bridge & DEX Aggregation” framing):
+- LI.FI positions itself as a **multi-chain routing layer** for swaps, transfers, and payments, exposed through **API / SDK / Widget**.  
+  Canonical overview: [Why LI.FI & What is LI.FI](https://docs.li.fi/overview/what-is-li.fi)
+
+Developer entry points:
+- SDK overview: [LI.FI SDK Overview](https://docs.li.fi/sdk/overview)
+- API docs (base URL `https://li.quest/v1`): [LI.FI API Overview](https://apidocs.li.fi/)
+- SDK package (good Context7 candidate): [`@lifi/sdk`](https://www.npmjs.com/package/@lifi/sdk)
+
+MCP angle:
+- LI.FI appears to have an MCP server implementation on GitHub: `https://github.com/lifinance/lifi-mcp`
+  - Treat any “execute swaps/bridges from an AI tool” flow as **high risk**: use test wallets / small funds only.
+


### PR DESCRIPTION
## Summary
- Add repo-local `.cursor/mcp.json` with commonly used MCP server configs (env-referenced only).
- Update devcontainer to support MCP tooling (Go/Python toolchain, PATH tweaks, env passthrough).
- Add `.devcontainer/hackmoney-tools/` scratchpad deps + `hackmoney.md` notes.

## Test plan
- [ ] Rebuild devcontainer
- [ ] Sanity-check MCP servers start (no secrets committed)