### PR TITLE
CI: fix npm ci lockfile sync (fastestsmallesttextencoderdecoder)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
-        "concurrently": "^9.2.1"
+        "concurrently": "^9.2.1",
+        "fastestsmallesttextencoderdecoder": "1.0.22"
       },
       "engines": {
         "node": ">=22 <23"
@@ -12381,6 +12382,13 @@
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/fastq": {
       "version": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
-    "concurrently": "^9.2.1"
+    "concurrently": "^9.2.1",
+    "fastestsmallesttextencoderdecoder": "1.0.22"
   },
   "keywords": [
     "x402",


### PR DESCRIPTION
## Summary
- Fix CI `npm ci` failing with `EUSAGE` / `Missing: fastestsmallesttextencoderdecoder@1.0.22 from lock file`.
- Add `fastestsmallesttextencoderdecoder@1.0.22` to root `devDependencies` so optional Solana peer deps are represented in `package-lock.json`.

## Notes
- This does **not** change runtime code; it only makes clean installs deterministic.
- Peer dependency warnings about `@solana/kit` remain warnings; the hard failure was lockfile sync.

## Test plan
- `npm ci` (passes locally)