### PR TITLE
Issue #18: document quote-mode vs paid-mode behavior

### DIFF
--- a/docs/proof-concepts.md
+++ b/docs/proof-concepts.md
@@ -85,10 +85,17 @@ The middleware behaves differently depending on whether the request includes pay
 
 - **Quote mode**: no `X-PAYMENT` header
   - The server responds `402` with `accepts[]` (payment requirements).
-  - **API providers are not called** (to avoid paid-request vendor calls during discovery).
-  - Metadata may mark some checks as `quoted: true` when computing prices/fees.
+  - **API providers are not called** (to avoid vendor/paid verifier calls during discovery and pricing negotiation).
+  - **Chain providers may still be called** (read-only RPC checks are allowed) to compute an accurate quote.
+  - If the route policy selects an **API provider** (e.g. `self_api`, `vlayer_api`), the middleware treats that claim as **"quoted"**:
+    - it is *assumed verified for quote calculation* (so clients can see discounted pricing and verification fees/commission),
+    - it is reported in metadata as `quoted: true`,
+    - it is **re-verified for real** once the client retries with payment.
 
 - **Paid mode**: includes `X-PAYMENT`
   - The server verifies payment and (if configured) performs proof verification via the configured providers.
   - The route handler can read `req.verificationMetadata`.
+  - Any **required claims** used for access control (`requiredClaims` / `accessControl`) are enforced **after payment verifies**:
+    - success → route handler runs
+    - failure → `403` (hard proof-gating)
 

--- a/packages/x402-zkx402/README.md
+++ b/packages/x402-zkx402/README.md
@@ -145,6 +145,17 @@ Behavior:
 - In **quote mode** (no `X-PAYMENT`), the server still returns `402` with `accepts[]`.
 - In **paid mode**, after payment verifies, the server verifies required claims and returns **403** if they fail.
 
+#### Quote-mode vs paid-mode for API providers (important)
+
+When a route’s `proofPolicy` allows an **API provider** (e.g. `self_api`, `vlayer_api`):
+
+- **Quote mode** (no `X-PAYMENT`):
+  - the middleware **does not call** the vendor API
+  - the claim is treated as **quoted** (assumed verified for pricing) so the client can see the intended discount + any verification fees/commission
+- **Paid mode** (with `X-PAYMENT`):
+  - the middleware performs the real verification (including vendor API calls when configured)
+  - `requiredClaims` / `accessControl` are enforced *after* payment verification (returning `403` on failure)
+
 ### Content Metadata
 
 Attach zkproof-like strings as metadata (not enforced by this middleware):


### PR DESCRIPTION
## Summary
- Clarify quote-mode vs paid-mode semantics, especially for API proof providers (`self_api`, `vlayer_api`).
- Document that quote-mode skips vendor API calls and marks those checks as `quoted: true`, while paid-mode performs real verification and enforces access control after payment.

Closes #18.

## Test plan
- Docs only.