### PR TITLE
Issue #10: remove dummy client-side verification

### DIFF
--- a/apps/demo/client/app/consumer/page.tsx
+++ b/apps/demo/client/app/consumer/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { useState, useEffect } from 'react';
 import { useCurrentUser, useIsSignedIn } from '@coinbase/cdp-hooks';
+import { isHumanVerifiedOnBase } from '@/lib/verification';
 
 function ConsumerPageInner() {
   const { isSignedIn } = useIsSignedIn();
@@ -16,12 +17,19 @@ function ConsumerPageInner() {
 
   const address = currentUser?.evmAccounts?.[0];
 
-  // Check verification status from localStorage
   useEffect(() => {
-    if (address) {
-      const verified = localStorage.getItem(`verified_${address}`) === 'true';
-      setIsVerified(verified);
-    }
+    let cancelled = false;
+    (async () => {
+      if (!address) return;
+      const verified = await isHumanVerifiedOnBase({
+        walletAddress: address,
+        baseRegistryAddress: process.env.NEXT_PUBLIC_BASE_REGISTRY_ADDRESS,
+      });
+      if (!cancelled) setIsVerified(verified);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [address]);
 
   return (

--- a/apps/demo/client/app/demo/page.tsx
+++ b/apps/demo/client/app/demo/page.tsx
@@ -356,16 +356,6 @@ function DemoPageInner() {
     setPaymentInfo(null);
 
     try {
-      const isHumanVerified =
-        typeof window !== 'undefined' &&
-        localStorage.getItem(`verified_${address}`) === 'true';
-
-      if (!isHumanVerified) {
-        throw new Error(
-          'verification required: go to /verify and complete proof-of-humanity before accessing classified content',
-        );
-      }
-
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 25_000);
 
@@ -388,7 +378,11 @@ function DemoPageInner() {
             : body?.error
               ? String(body.error)
               : `API request failed: ${response.status}`;
-        throw new Error(msg);
+        throw new Error(
+          response.status === 403
+            ? `${msg}. If you haven’t verified yet, go to /verify and complete proof-of-humanity.`
+            : msg,
+        );
       }
 
       const data: ApiResponse = await response.json();

--- a/apps/demo/client/app/verify/page.tsx
+++ b/apps/demo/client/app/verify/page.tsx
@@ -19,6 +19,7 @@ import {
 import { ethers } from 'ethers';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { isHumanVerifiedOnBase } from '@/lib/verification';
 
 // Contract addresses (you'll update these after deployment)
 const CELO_BRIDGE_ADDRESS =
@@ -200,18 +201,14 @@ export default function VerifyPage() {
     if (!address) return;
 
     try {
-      const provider = new ethers.BrowserProvider((window as any).ethereum);
-      const registry = new ethers.Contract(
-        BASE_REGISTRY_ADDRESS,
-        ['function isVerified(address) view returns (bool)'],
-        provider
-      );
-
-      const verified = await registry.isVerified(address);
+      const verified = await isHumanVerifiedOnBase({
+        walletAddress: address,
+        baseRegistryAddress: BASE_REGISTRY_ADDRESS,
+      });
       setIsVerified(verified);
       if (verified) {
         setVerificationStatus('verified');
-        // Store verification status in localStorage
+        // Convenience only (not a proof): persist UI state.
         localStorage.setItem(`verified_${address}`, 'true');
       }
     } catch (err) {

--- a/apps/demo/client/lib/verification.ts
+++ b/apps/demo/client/lib/verification.ts
@@ -1,0 +1,30 @@
+import { ethers } from 'ethers';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const BASE_SEPOLIA_RPC_URL = 'https://sepolia.base.org';
+
+export async function isHumanVerifiedOnBase(opts: {
+  walletAddress: string | null | undefined;
+  baseRegistryAddress: string | null | undefined;
+  rpcUrl?: string;
+}): Promise<boolean> {
+  const walletAddress = (opts.walletAddress || '').trim();
+  const baseRegistryAddress = (opts.baseRegistryAddress || '').trim();
+  const rpcUrl = (opts.rpcUrl || BASE_SEPOLIA_RPC_URL).trim();
+
+  if (!walletAddress) return false;
+  if (!baseRegistryAddress || baseRegistryAddress.toLowerCase() === ZERO_ADDRESS) return false;
+
+  try {
+    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const registry = new ethers.Contract(
+      baseRegistryAddress,
+      ['function isVerified(address) view returns (bool)'],
+      provider,
+    );
+    return Boolean(await registry.isVerified(walletAddress));
+  } catch {
+    return false;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Remove localStorage-based pre-checks that implied client-side proof verification.
- Rely on server-side access control outcomes (403 on paid requests when required claims fail).
- Replace Marketplace/consumer verification gating with a read-only on-chain Base registry check.

Closes #10.

## Test plan
- `npm run build --workspace=apps/demo/client`
- Manual: call `/motivate-gated` unverified → expect 403 + helpful message; verified → 200.