### PR TITLE
Issue #12: improve claim verification outcomes + reason codes

### DIFF
--- a/packages/x402-zkx402/README.md
+++ b/packages/x402-zkx402/README.md
@@ -317,7 +317,17 @@ app.get("/api/data", (req, res) => {
   //     isValid: true,
   //     verifiedCount: 1,
   //     totalRequired: 1,
-  //     verificationDetails: [...]
+  //     verificationDetails: [
+  //       {
+  //         claimKey: "human",
+  //         claim: { type: "human" },
+  //         verified: true,
+  //         status: "verified",
+  //         provider: "self",
+  //         quoted: false,
+  //         attempts: [{ provider: "self", ok: true, status: "verified" }]
+  //       }
+  //     ]
   //   }
   // }
 });

--- a/packages/x402-zkx402/src/middleware.js
+++ b/packages/x402-zkx402/src/middleware.js
@@ -291,7 +291,15 @@ export function paymentMiddleware(payTo, routes, facilitator, paywall) {
           const ck = claimKey(claim);
           const presentedByClient = presentedKeys.has(ck);
           if (requirePresentation && !presentedByClient) {
-            return { claimKey: ck, claim, verified: false, reason: "not_presented" };
+            return {
+              claimKey: ck,
+              claim,
+              verified: false,
+              status: VerifyStatus.NOT_VERIFIED,
+              reason: "not_presented",
+              quoted: false,
+              attempts: [],
+            };
           }
 
           // Client can optionally constrain which provider to use (soft checks).
@@ -328,7 +336,19 @@ export function paymentMiddleware(payTo, routes, facilitator, paywall) {
           const isApiProvider = providerObj?.kind === "api";
 
           if (quoteOnly && isApiProvider) {
-            routed = { status: VerifyStatus.VERIFIED, provider: selectedProvider, quoted: true };
+            routed = {
+              status: VerifyStatus.VERIFIED,
+              provider: selectedProvider,
+              quoted: true,
+              attempts: [
+                {
+                  provider: selectedProvider,
+                  ok: true,
+                  status: VerifyStatus.VERIFIED,
+                  reason: "quoted",
+                },
+              ],
+            };
           } else {
             const startedAt = Date.now();
             routed = await verifyClaimWithPolicy({
@@ -373,7 +393,19 @@ export function paymentMiddleware(payTo, routes, facilitator, paywall) {
               claimKey: ck,
               claim,
               verified: false,
+              status: VerifyStatus.NOT_IMPLEMENTED,
               reason: "not_implemented",
+              attempts: Array.isArray(routed.attempts) ? routed.attempts : undefined,
+            };
+          }
+          if (routed.status === VerifyStatus.NOT_CONFIGURED) {
+            return {
+              claimKey: ck,
+              claim,
+              verified: false,
+              status: VerifyStatus.NOT_CONFIGURED,
+              reason: routed.reason || "not_configured",
+              attempts: Array.isArray(routed.attempts) ? routed.attempts : undefined,
             };
           }
           if (routed.status === VerifyStatus.ERROR) {
@@ -381,6 +413,7 @@ export function paymentMiddleware(payTo, routes, facilitator, paywall) {
               claimKey: ck,
               claim,
               verified: false,
+              status: VerifyStatus.ERROR,
               reason: routed.reason || "verification_error",
               attempts: Array.isArray(routed.attempts) ? routed.attempts : undefined,
             };
@@ -399,6 +432,7 @@ export function paymentMiddleware(payTo, routes, facilitator, paywall) {
             claimKey: ck,
             claim,
             verified: routed.status === VerifyStatus.VERIFIED,
+            status: routed.status,
             provider: routed.provider,
             verificationCost,
             quoted: Boolean(routed.quoted),

--- a/packages/x402-zkx402/src/proofs/router.js
+++ b/packages/x402-zkx402/src/proofs/router.js
@@ -4,6 +4,7 @@ export const VerifyStatus = {
   VERIFIED: "verified",
   NOT_VERIFIED: "not_verified",
   NOT_IMPLEMENTED: "not_implemented",
+  NOT_CONFIGURED: "not_configured",
   ERROR: "error",
 };
 
@@ -44,7 +45,7 @@ export async function verifyClaimWithPolicy({
   if (!methodName) {
     return {
       status: VerifyStatus.NOT_IMPLEMENTED,
-      reason: `Claim not implemented in chain-only mode: ${claim.type}`,
+      reason: `Claim type not implemented: ${claim.type}`,
     };
   }
 
@@ -73,18 +74,25 @@ export async function verifyClaimWithPolicy({
   }
 
   const attempts = [];
+  let sawNotVerified = false;
+  let sawNonConfiguredFailure = false;
+  let lastNotVerifiedProvider = null;
+
   for (const provider of finalProviders) {
     const fn = provider?.[methodName];
     if (typeof fn !== "function") continue;
     const result = await fn({ ...(context || {}), claim, policy });
     if (!result?.ok) {
+      const status = String(result?.status ?? VerifyStatus.ERROR);
       attempts.push({
         provider: provider?.name ?? "unknown",
         ok: false,
-        status: result?.status ?? "error",
+        status,
         reason: result?.reason ?? "provider_error",
       });
-      // continue trying other providers in chain-only mode
+      if (status !== VerifyStatus.NOT_CONFIGURED) {
+        sawNonConfiguredFailure = true;
+      }
       continue;
     }
     attempts.push({
@@ -92,14 +100,48 @@ export async function verifyClaimWithPolicy({
       ok: true,
       status: result?.verified ? VerifyStatus.VERIFIED : VerifyStatus.NOT_VERIFIED,
     });
-    return result.verified
-      ? { status: VerifyStatus.VERIFIED, provider: provider.name, attempts }
-      : { status: VerifyStatus.NOT_VERIFIED, provider: provider.name, attempts };
+    if (result.verified) {
+      return { status: VerifyStatus.VERIFIED, provider: provider.name, attempts };
+    }
+    // If this provider says "not verified", try the next provider in policy order.
+    sawNotVerified = true;
+    lastNotVerifiedProvider = provider?.name ?? null;
   }
 
+  if (attempts.length === 0) {
+    return {
+      status: VerifyStatus.ERROR,
+      reason: "No provider implemented the required verification method",
+      attempts,
+    };
+  }
+
+  // If every provider failed only due to missing configuration, surface that explicitly.
+  const allNotConfigured = attempts.every(
+    (a) => a?.ok === false && String(a?.status) === VerifyStatus.NOT_CONFIGURED
+  );
+  if (allNotConfigured) {
+    return {
+      status: VerifyStatus.NOT_CONFIGURED,
+      reason: "All providers were not configured",
+      attempts,
+    };
+  }
+
+  // If at least one provider produced a definitive "not verified" result, surface NOT_VERIFIED.
+  if (sawNotVerified && !sawNonConfiguredFailure) {
+    return {
+      status: VerifyStatus.NOT_VERIFIED,
+      reason: "No provider verified the claim",
+      provider: lastNotVerifiedProvider || undefined,
+      attempts,
+    };
+  }
+
+  // Mixed failures (API errors, invalid input, etc.) are treated as ERROR to avoid false negatives.
   return {
     status: VerifyStatus.ERROR,
-    reason: "All providers failed or were not configured",
+    reason: "All providers failed",
     attempts,
   };
 }

--- a/packages/x402-zkx402/src/types.d.ts
+++ b/packages/x402-zkx402/src/types.d.ts
@@ -152,9 +152,36 @@ export interface ProofVerificationDetail {
   verified: boolean;
 
   /**
+   * Machine-readable per-claim status.
+   *
+   * Expected values:
+   * - "verified"
+   * - "not_verified"
+   * - "not_implemented"
+   * - "not_configured"
+   * - "error"
+   */
+  status: string;
+
+  /**
    * Optional reason if verification failed
    */
   reason?: string;
+
+  /**
+   * Provider selected by routing (when available).
+   */
+  provider?: string;
+
+  /**
+   * Whether the claim was treated as "quoted" (e.g., API provider skipped in quote-mode).
+   */
+  quoted?: boolean;
+
+  /**
+   * Optional pricing breakdown for verification fees (USD micros).
+   */
+  verificationCost?: any;
 
   /**
    * Optional API verification result (for API-backed providers like `self_api`, `vlayer_api`)

--- a/packages/x402-zkx402/test/router.test.js
+++ b/packages/x402-zkx402/test/router.test.js
@@ -99,6 +99,40 @@ test("router: honors preferenceOrder + allowedProviders", async () => {
   assert.equal(res.provider, "self");
 });
 
+test("router: tries next provider if earlier provider returns verified=false", async () => {
+  const calls = [];
+  const providers = [
+    {
+      name: "first",
+      verifyHuman: async () => {
+        calls.push("first");
+        return { ok: true, verified: false };
+      },
+    },
+    {
+      name: "second",
+      verifyHuman: async () => {
+        calls.push("second");
+        return { ok: true, verified: true };
+      },
+    },
+  ];
+
+  const res = await verifyClaimWithPolicy({
+    claim: { type: ClaimType.HUMAN },
+    policy: {
+      allowedProviders: ["first", "second"],
+      preferenceOrder: ["first", "second"],
+    },
+    providers,
+    context: { walletAddress: "0x0000000000000000000000000000000000000001" },
+  });
+
+  assert.deepEqual(calls, ["first", "second"]);
+  assert.equal(res.status, VerifyStatus.VERIFIED);
+  assert.equal(res.provider, "second");
+});
+
 test("router: tries next provider if earlier provider errors", async () => {
   const calls = [];
   const providers = [


### PR DESCRIPTION
## Summary
- Add explicit claim verification statuses (including `not_configured`) and preserve provider `attempts[]` for debugging.
- Router now continues after `ok: true, verified: false` to allow fallback providers.
- Extend `verificationMetadata.verificationResult.verificationDetails[]` with `status` and make quote-mode `quoted` attempts explicit.
- Update docs example payload.

Closes #12.

## Test plan
- `npm test --workspace=packages/x402-zkx402`